### PR TITLE
Animation sets

### DIFF
--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -3,8 +3,9 @@ from animation import Animation
 import big_cube_walk
 import swoopy_town
 
-# A dictionary where the key is the layout class the animation requires
-# and the value is the layout
+# A dictionary where
+#    key: name of the layout class as a string
+#    value: dictionary of animations keyed by name
 animations_by_layout = {}
 for animation in Animation.__subclasses__():
     if animation.layout_type in animations_by_layout:

--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -1,6 +1,7 @@
 from animation import Animation
 
 import big_cube_walk
+import swoopy_town
 
 # A dictionary where the key is the layout class the animation requires
 # and the value is the layout

--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -7,7 +7,7 @@ import big_cube_walk
 animations_by_layout = {}
 for animation in Animation.__subclasses__():
     if animation.layout_type in animations_by_layout:
-        animations_by_layout[animation.layout_type].append(animation)
+        animations_by_layout[animation.layout_type][animation.__name__] = animation
 
     else:
-        animations_by_layout[animation.layout_type] = [animation]
+        animations_by_layout[animation.layout_type] = {animation.__name__: animation}

--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -1,0 +1,13 @@
+from animation import Animation
+
+import big_cube_walk
+
+# A dictionary where the key is the layout class the animation requires
+# and the value is the layout
+animations_by_layout = {}
+for animation in Animation.__subclasses__():
+    if animation.layout_type in animations_by_layout:
+        animations_by_layout[animation.layout_type].append(animation)
+
+    else:
+        animations_by_layout[animation.layout_type] = [animation]

--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -1,5 +1,6 @@
 from animation import Animation
 
+# Import animations here to make them detectable to higher level code
 import big_cube_walk
 import swoopy_town
 

--- a/core/animations/__init__.py
+++ b/core/animations/__init__.py
@@ -14,3 +14,15 @@ for animation in Animation.__subclasses__():
 
     else:
         animations_by_layout[animation.layout_type] = {animation.__name__: animation}
+
+def possible_animations(name):
+    possible_animations = {}
+    if "Layout" in animations_by_layout:
+        possible_animations.update(animations_by_layout["Layout"])
+
+    if name in animations_by_layout:
+        possible_animations.update(animations_by_layout[name])
+
+    return possible_animations
+
+

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -1,11 +1,15 @@
 import numpy as np
 
+from core.layouts.pixel_list import PixelList
+
 class Animation(object):
     """
         The animation class is used to generate a pattern for an OutputDevice
         The params dict represents high level Params represent
         high level parameters that are configured during development or live
     """
+    layout_type = PixelList
+
     def __init__(self):
         # Dictionary of parameters, useful for higher level code
         # to be able to retrieve an animation's params

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -1,14 +1,12 @@
 import numpy as np
 
-from core.layouts.pixel_list import PixelList
-
 class Animation(object):
     """
         The animation class is used to generate a pattern for an OutputDevice
         The params dict represents high level Params represent
         high level parameters that are configured during development or live
     """
-    layout_type = PixelList
+    layout_type = "PixelList"
 
     def __init__(self):
         # Dictionary of parameters, useful for higher level code

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -16,6 +16,9 @@ class Animation(object):
         # Initialise _fft var. This should only be get/set from the properties below
         self._fft = np.zeros((7,))
 
+        # This defines the layout used for animation
+        self.layout = None
+
     @property
     def fft(self):
         """

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -6,7 +6,7 @@ class Animation(object):
         The params dict represents high level Params represent
         high level parameters that are configured during development or live
     """
-    layout_type = "PixelList"
+    layout_type = "Layout"
 
     def __init__(self):
         # Dictionary of parameters, useful for higher level code

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -43,3 +43,4 @@ class Animation(object):
             This method is called to update the pixel colors
         """
         pass
+

--- a/core/animations/animation.py
+++ b/core/animations/animation.py
@@ -1,11 +1,16 @@
 import numpy as np
 
+from core.layouts.layout import Layout
+
 class Animation(object):
     """
         The animation class is used to generate a pattern for an OutputDevice
         The params dict represents high level Params represent
         high level parameters that are configured during development or live
     """
+
+    # Name of the layout class name as a string that the animation should be constructed with
+    # "Layout" indicates a generic animation that can operate on any layout
     layout_type = "Layout"
 
     def __init__(self):
@@ -17,7 +22,7 @@ class Animation(object):
         self._fft = np.zeros((7,))
 
         # This defines the layout used for animation
-        self.layout = None
+        self.layout = Layout()
 
     @property
     def fft(self):

--- a/core/animations/big_cube_walk.py
+++ b/core/animations/big_cube_walk.py
@@ -14,18 +14,15 @@ class BigCubeWalk(Animation):
             period is the number of seconds it takes a color to lap the cube
             hue_range defines the range of colors used as a prop of the color wheel
         """
-
         super(BigCubeWalk, self).__init__()
+
+        self.layout = big_cube
 
         self.add_param("period", period)
         self.add_param("hue_range", hue_range)
 
-        # TODO: Generalise layout dependencies. 
-        # E.g. assocaite on animatios to the layouts they have and having general ones 
-        self.big_cube = big_cube
-
     def update(self):
-        pixels = self.big_cube.pixels
+        pixels = self.layout.pixels
 
         period = self.params["period"]
         hue_range = self.params["hue_range"]

--- a/core/animations/big_cube_walk.py
+++ b/core/animations/big_cube_walk.py
@@ -6,7 +6,7 @@ import numpy as np
 import colorsys
 
 class BigCubeWalk(Animation):
-    layout_type = BigCube
+    layout_type = "BigCube"
 
     def __init__(self, big_cube, period=5, hue_range=0.2):
         """

--- a/core/animations/big_cube_walk.py
+++ b/core/animations/big_cube_walk.py
@@ -1,9 +1,13 @@
 from animation import Animation
+from core.layouts.big_cube import BigCube
+
 import time
 import numpy as np
 import colorsys
 
 class BigCubeWalk(Animation):
+    layout_type = BigCube
+
     def __init__(self, big_cube, period=5, hue_range=0.2):
         """
             Shifts pixel colors along a hue range in the order that the led strips woulf be laid in

--- a/core/animations/swoopy_town.py
+++ b/core/animations/swoopy_town.py
@@ -29,7 +29,7 @@ class SwoopyTown(Animation):
             x,y,z = pixel.location
 
             h = 0.5*(1 + np.sin(2*np.pi*f*t + w*x))
-            s = 0.5*(1 + np.sin(2*np.pi*f*t+ w*y))
+            s = 0.5*(1 + np.sin(2*np.pi*f*t + w*y))
             v = 0.5*(1 + np.sin(2*np.pi*f*t + w*z))
 
             pixel.set_hsv(h,s,v)

--- a/core/animations/swoopy_town.py
+++ b/core/animations/swoopy_town.py
@@ -4,7 +4,7 @@ import time
 import numpy as np
 
 class SwoopyTown(Animation):
-    layout_type="PixelList"
+    layout_type="Layout"
 
     def __init__(self, pixel_list, period=1, wavelength=2):
         """
@@ -28,8 +28,8 @@ class SwoopyTown(Animation):
         for pixel in pixels:
             x,y,z = pixel.location
 
-            h = np.sin(2*np.pi*f + w*x)
-            s = np.sin(2*np.pi*f + w*y)
-            v = np.sin(2*np.pi*f + w*z)
+            h = np.sin(2*np.pi*f*t + w*x)
+            s = np.sin(2*np.pi*f*t+ w*y)
+            v = np.sin(2*np.pi*f*t + w*z)
 
             pixel.set_hsv(h,s,v)

--- a/core/animations/swoopy_town.py
+++ b/core/animations/swoopy_town.py
@@ -1,0 +1,35 @@
+from animation import Animation
+
+import time
+import numpy as np
+
+class SwoopyTown(Animation):
+    layout_type="PixelList"
+
+    def __init__(self, pixel_list, period=1, wavelength=2):
+        """
+            Swoopy spatially driven pattern for testing
+        """
+
+        super(SwoopyTown, self).__init__()
+
+        self.layout = pixel_list
+
+        self.add_params("period", period)
+        self.add_params("wavelength", wavelength)
+
+    def update(self):
+        pixels = self.layout.pixels
+
+        t = time.time()
+        f = 1.0/self.params["period"]
+        w = self.params["wavelength"]
+
+        for pixel in pixels:
+            x,y,z = pixel.location
+
+            h = np.sin(2*np.pi*f + w*x)
+            s = np.sin(2*np.pi*f + w*y)
+            v = np.sin(2*np.pi*f + w*z)
+
+            pixel.set_hsv(h,s,v)

--- a/core/animations/swoopy_town.py
+++ b/core/animations/swoopy_town.py
@@ -4,21 +4,25 @@ import time
 import numpy as np
 
 class SwoopyTown(Animation):
+    # Generic, this animation should work on any layout
     layout_type="Layout"
 
-    def __init__(self, pixel_list, period=1, wavelength=2):
+    def __init__(self, layout, period=1, wavelength=2):
         """
             Swoopy spatially driven pattern for testing
         """
 
         super(SwoopyTown, self).__init__()
 
-        self.layout = pixel_list
+        self.layout = layout
 
         self.add_param("period", period)
         self.add_param("wavelength", wavelength)
 
     def update(self):
+        """
+            Just a load-o-sines
+        """
         pixels = self.layout.pixels
 
         t = time.time()

--- a/core/animations/swoopy_town.py
+++ b/core/animations/swoopy_town.py
@@ -15,8 +15,8 @@ class SwoopyTown(Animation):
 
         self.layout = pixel_list
 
-        self.add_params("period", period)
-        self.add_params("wavelength", wavelength)
+        self.add_param("period", period)
+        self.add_param("wavelength", wavelength)
 
     def update(self):
         pixels = self.layout.pixels
@@ -28,8 +28,8 @@ class SwoopyTown(Animation):
         for pixel in pixels:
             x,y,z = pixel.location
 
-            h = np.sin(2*np.pi*f*t + w*x)
-            s = np.sin(2*np.pi*f*t+ w*y)
-            v = np.sin(2*np.pi*f*t + w*z)
+            h = 0.5*(1 + np.sin(2*np.pi*f*t + w*x))
+            s = 0.5*(1 + np.sin(2*np.pi*f*t+ w*y))
+            v = 0.5*(1 + np.sin(2*np.pi*f*t + w*z))
 
             pixel.set_hsv(h,s,v)

--- a/core/devices/__init__.py
+++ b/core/devices/__init__.py
@@ -1,18 +1,32 @@
 import core.utilities.process_descriptor as pd
 from output_device import OutputDevice
+from input_device import InputDevice
 
 # To be able construct a device, all you have to is import it here 
 import cube_strip
 import lonely
 import big_cube_device
+import fft_device
 
-# Generates dictionary with the class name as key and class as value. 
-# Useful for constructing device class instances
-output_device_dict = {}
-for output_device in OutputDevice.__subclasses__():
-    output_device_dict[output_device.__name__] = output_device
-
+# Returns a list constructed devices given a list of initialisation data
 def construct_output_devices(output_devices_data_dict):
+    return construct_devices(output_devices_data_dict, constructor_dict(OutputDevice))
+
+def construct_input_devices(input_devices_data_dict):
+    return construct_devices(input_devices_data_dict, constructor_dict(InputDevice))
+
+def constructor_dict(device_superclass):
+    """
+        Generates dictionary with the class name as key and class as value. 
+        Useful for constructing device class instances
+    """
+    constructors_by_name = {}
+    for device in device_superclass.__subclasses__():
+        constructors_by_name[device.__name__] = device
+
+    return constructors_by_name
+
+def construct_devices(data_dict, device_constructor_dict):
     """
         Returns a list constructed devices given a list of initialisation data
         Each element in devices_data_dict should be a dictionary with format 
@@ -20,17 +34,17 @@ def construct_output_devices(output_devices_data_dict):
             "type": <name of device class>,
             "args": <dict of constructor args>
         }
+        
+        TODO: Error handling
     """
+    devices = []
 
-    # TODO: Error handling
-
-    output_devices = []
     # Construct device from the dictionary the device_dict above
-    for output_device_data in output_devices_data_dict:
-        output_device_constructor = output_device_dict[output_device_data["type"]]
-        output_devices.append(output_device_constructor(**output_device_data["args"]))
+    for device_data in data_dict:
+        device_constructor = device_constructor_dict[device_data["type"]]
+        devices.append(device_constructor(**device_data["args"]))
 
-    return output_devices
+    return devices
 
 def combine_channel_dicts(output_devices):
     """ 

--- a/core/devices/big_cube_device.py
+++ b/core/devices/big_cube_device.py
@@ -16,7 +16,7 @@ class BigCubeDevice(OutputDevice):
     def __init__(self, channel, led_spacing, strip_spacing):
         super(BigCubeDevice, self).__init__()
 
-        self.big_cube = BigCube(led_spacing, strip_spacing)
+        self.layout = BigCube(led_spacing, strip_spacing)
 
         # TODO: Generalise so we can actively switch between animation sets
         self.animation = BigCubeWalk(self.big_cube)

--- a/core/devices/big_cube_device.py
+++ b/core/devices/big_cube_device.py
@@ -19,10 +19,10 @@ class BigCubeDevice(OutputDevice):
         self.layout = BigCube(led_spacing, strip_spacing)
 
         # TODO: Generalise so we can actively switch between animation sets
-        self.animation = BigCubeWalk(self.big_cube)
+        self.animation = BigCubeWalk(self.layout)
 
         # Form pixels by channel dict
         self.pixels_by_channel = {
-            channel: self.big_cube.pixels
+            channel: self.layout.pixels
         }
 

--- a/core/devices/device.py
+++ b/core/devices/device.py
@@ -40,22 +40,6 @@ class Device(object):
         """
         return get_nowait(self.out_queue)
 
-def get_device_out_queues(devices):
-    """
-        Combines data from a set of input devices
-    """
-    data = []
-    for device in devices:
-        while True:
-            item = device.get_in_queue()
-
-            if item is None:
-                break
-            
-            else:
-                data.append(item)
-
-    return data
 
 def get_nowait(queue):
     """

--- a/core/devices/device.py
+++ b/core/devices/device.py
@@ -4,7 +4,7 @@ from Queue import Empty
 from core.layouts.pixel_list import PixelList
 
 class Device(object):
-    layout_type = PixelList
+    layout_type = "Layout"
 
     def __init__(self):
         # Output queue

--- a/core/devices/device.py
+++ b/core/devices/device.py
@@ -1,8 +1,6 @@
 from multiprocessing import Process, Queue, Lock
 from Queue import Empty
 
-from core.layouts.pixel_list import PixelList
-
 class Device(object):
     layout_type = "Layout"
 

--- a/core/devices/device.py
+++ b/core/devices/device.py
@@ -40,6 +40,22 @@ class Device(object):
         """
         return get_nowait(self.out_queue)
 
+def get_device_out_queues(devices):
+    """
+        Combines data from a set of input devices
+    """
+    data = []
+    for device in devices:
+        while True:
+            item = device.get_in_queue()
+
+            if item is None:
+                break
+            
+            else:
+                data.append(item)
+
+    return data
 
 def get_nowait(queue):
     """

--- a/core/devices/device.py
+++ b/core/devices/device.py
@@ -1,7 +1,11 @@
 from multiprocessing import Process, Queue, Lock
 from Queue import Empty
 
+from core.layouts.pixel_list import PixelList
+
 class Device(object):
+    layout_type = PixelList
+
     def __init__(self):
         # Output queue
         self.out_queue = Queue()

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -14,7 +14,6 @@ class OutputDevice(Device):
         TODO: abstract for output/input device
     """
     fps = 30
-    layout_type = "Layout"
 
     def __init__(self):
         """

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -66,7 +66,10 @@ class OutputDevice(Device):
             params = {}
 
         # Construct new animation
-        self.animation = animations[name](self.layout, **params)
+        # TODO: Thread safety required?
+        new_animation = animations[name](self.layout, **params)
+        new_animation.fft = self.animation.fft
+        self.animation = new_animation
 
     def animations_list(self):
         """

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -49,11 +49,13 @@ class OutputDevice(Device):
             Switches the current animation
             Params is a set of initialisation parameters
         """
-        if self.layout.__class__.__name__ not in animations_by_layout:
-            # TODO: Log error
-            return
+        # Dict of possible animations include the generic the Layout type and layout specific types
+        animations = {}
+        if "Layout" in animations_by_layout:
+            animations.update(animations_by_layout["Layout"])
 
-        animations = animations_by_layout[self.layout.__class__.__name__]
+        if self.layout.__class__.__name__ in animations_by_layout:
+            animations.update(animations_by_layout[self.layout.__class__.__name__])
 
         if name not in animations:
             # TODO: Log error

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -50,14 +50,14 @@ class OutputDevice(Device):
         # Dict of possible animations include:
         #   - generic Layout type
         #   - layout specific types
-        animations = {}
+        possible_animations = {}
         if "Layout" in animations_by_layout:
-            animations.update(animations_by_layout["Layout"])
+            possible_animations.update(animations_by_layout["Layout"])
 
         if self.layout.__class__.__name__ in animations_by_layout:
-            animations.update(animations_by_layout[self.layout.__class__.__name__])
+            possible_animations.update(animations_by_layout[self.layout.__class__.__name__])
 
-        if name not in animations:
+        if name not in possible_animations:
             # TODO: Log error
             return
 
@@ -65,8 +65,7 @@ class OutputDevice(Device):
             params = {}
 
         # Construct new animation
-        # TODO: Thread safety required?
-        new_animation = animations[name](self.layout, **params)
+        new_animation = possible_animations[name](self.layout, **params)
         new_animation.fft = self.animation.fft
         self.animation = new_animation
 

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -5,6 +5,7 @@ import numpy as np
 from device import Device
 from core.utilities.sleep_timer import SleepTimer
 
+from core.animations import animations_by_layout
 from core.animations.animation import Animation
 from core.layouts.pixel_list import PixelList
 
@@ -42,15 +43,20 @@ class OutputDevice(Device):
 
             sleep_timer.sleep()
 
-    def set_animation(self, name):
+    def set_animation(self, name, params={}):
         """
             Switches the current animation
+            Params is a set of initialisation parameters
         """
-        pass
+        if name not in animations_by_layout:
+            # TODO: Log error
+            return
+
+        self.animation = animations_by_layout[name](**params)
 
     def animations_list(self):
         """
-            Returns a list of possible animations
+            TODO: Returns a list of possible animations
         """
         pass
 

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -27,6 +27,7 @@ class OutputDevice(Device):
         self.pixels_by_channel = {}
 
         # The current active animation
+        self.layout = PixelList([])
         self.animation = Animation()
 
     def main(self):
@@ -43,7 +44,7 @@ class OutputDevice(Device):
 
             sleep_timer.sleep()
 
-    def set_animation(self, name, params={}):
+    def set_animation(self, name, params=None):
         """
             Switches the current animation
             Params is a set of initialisation parameters
@@ -52,7 +53,11 @@ class OutputDevice(Device):
             # TODO: Log error
             return
 
-        self.animation = animations_by_layout[name](**params)
+        if params is None:
+            params = {}
+
+        # Construct new animation
+        self.animation = animations_by_layout[name](layout, **params)
 
     def animations_list(self):
         """

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -4,10 +4,9 @@ import numpy as np
 
 from device import Device
 from core.utilities.sleep_timer import SleepTimer
-
 from core.animations import animations_by_layout
 from core.animations.animation import Animation
-from core.layouts.pixel_list import PixelList
+from core.layouts.layout import Layout
 
 class OutputDevice(Device):
     """
@@ -15,7 +14,7 @@ class OutputDevice(Device):
         TODO: abstract for output/input device
     """
     fps = 30
-    layout_type = "PixelList"
+    layout_type = "Layout"
 
     def __init__(self):
         """
@@ -27,7 +26,7 @@ class OutputDevice(Device):
         self.pixels_by_channel = {}
 
         # The current active animation
-        self.layout = PixelList([])
+        self.layout = Layout()
         self.animation = Animation()
 
     def main(self):

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -55,13 +55,7 @@ class OutputDevice(Device):
 
         animations = animations_by_layout[self.layout.__class__.__name__]
 
-        animation_constructor = None
-        for ani in animations:
-            if name == ani.__name__:
-                animation_constructor = ani
-                break
-
-        if not animation_constructor:
+        if name not in animations:
             # TODO: Log error
             return
 
@@ -69,7 +63,7 @@ class OutputDevice(Device):
             params = {}
 
         # Construct new animation
-        self.animation = animation_constructor(self.layout, **params)
+        self.animation = animations[name](self.layout, **params)
 
     def animations_list(self):
         """

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -49,7 +49,19 @@ class OutputDevice(Device):
             Switches the current animation
             Params is a set of initialisation parameters
         """
-        if name not in animations_by_layout:
+        if self.layout.__class__.__name__ not in animations_by_layout:
+            # TODO: Log error
+            return
+
+        animations = animations_by_layout[self.layout.__class__.__name__]
+
+        animation_constructor = None
+        for ani in animations:
+            if name == ani.__name__:
+                animation_constructor = ani
+                break
+
+        if not animation_constructor:
             # TODO: Log error
             return
 
@@ -57,7 +69,7 @@ class OutputDevice(Device):
             params = {}
 
         # Construct new animation
-        self.animation = animations_by_layout[name](layout, **params)
+        self.animation = animation_constructor(self.layout, **params)
 
     def animations_list(self):
         """

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from device import Device
 from core.utilities.sleep_timer import SleepTimer
-from core.animations import animations_by_layout
+from core.animations import animations_by_layout, possible_animations
 from core.animations.animation import Animation
 from core.layouts.layout import Layout
 
@@ -50,14 +50,9 @@ class OutputDevice(Device):
         # Dict of possible animations include:
         #   - generic Layout type
         #   - layout specific types
-        possible_animations = {}
-        if "Layout" in animations_by_layout:
-            possible_animations.update(animations_by_layout["Layout"])
+        poss_animations = self.possible_animations()
 
-        if self.layout.__class__.__name__ in animations_by_layout:
-            possible_animations.update(animations_by_layout[self.layout.__class__.__name__])
-
-        if name not in possible_animations:
+        if name not in poss_animations:
             # TODO: Log error
             return
 
@@ -69,11 +64,8 @@ class OutputDevice(Device):
         new_animation.fft = self.animation.fft
         self.animation = new_animation
 
-    def animations_list(self):
-        """
-            TODO: Returns a list of possible animations
-        """
-        pass
+    def possible_animations(self):
+        return possible_animations(self.layout.__class__.__name__)
 
     @property
     def pixel_colors_by_channel_255(self):

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -48,7 +48,9 @@ class OutputDevice(Device):
             Switches the current animation
             Params is a set of initialisation parameters
         """
-        # Dict of possible animations include the generic the Layout type and layout specific types
+        # Dict of possible animations include:
+        #   - generic Layout type
+        #   - layout specific types
         animations = {}
         if "Layout" in animations_by_layout:
             animations.update(animations_by_layout["Layout"])

--- a/core/devices/output_device.py
+++ b/core/devices/output_device.py
@@ -6,6 +6,7 @@ from device import Device
 from core.utilities.sleep_timer import SleepTimer
 
 from core.animations.animation import Animation
+from core.layouts.pixel_list import PixelList
 
 class OutputDevice(Device):
     """
@@ -13,6 +14,7 @@ class OutputDevice(Device):
         TODO: abstract for output/input device
     """
     fps = 30
+    layout_type = "PixelList"
 
     def __init__(self):
         """
@@ -39,6 +41,18 @@ class OutputDevice(Device):
             self.put(self.pixel_colors_by_channel_255)
 
             sleep_timer.sleep()
+
+    def set_animation(self, name):
+        """
+            Switches the current animation
+        """
+        pass
+
+    def animations_list(self):
+        """
+            Returns a list of possible animations
+        """
+        pass
 
     @property
     def pixel_colors_by_channel_255(self):

--- a/core/devices/pixel.py
+++ b/core/devices/pixel.py
@@ -1,3 +1,5 @@
+import colorsys
+
 class Pixel(object):
     """
         Pixel object holds location and color data
@@ -22,3 +24,9 @@ class Pixel(object):
             tuple scaled for 8-bit
         """
         return (255*self.r, 255*self.g, 255*self.b)
+
+    def set_hsv(h, s, v):
+        """
+            Sets pixel color given hsv values in range 0->1
+        """ 
+        self.r, self.g, self.b = colorsys.hsv_to_rgb(h,s,v)

--- a/core/devices/pixel.py
+++ b/core/devices/pixel.py
@@ -25,7 +25,7 @@ class Pixel(object):
         """
         return (255*self.r, 255*self.g, 255*self.b)
 
-    def set_hsv(h, s, v):
+    def set_hsv(self, h, s, v):
         """
             Sets pixel color given hsv values in range 0->1
         """ 

--- a/core/layouts/__init__.py
+++ b/core/layouts/__init__.py
@@ -1,0 +1,7 @@
+from layout import Layout
+
+import big_cube
+import pixel_list
+
+# A dictionary where key is name of layut as a string and the class as a value
+layouts_by_name = {layout.__name__: layout for layout in Layout.__subclasses__()}

--- a/core/layouts/__init__.py
+++ b/core/layouts/__init__.py
@@ -1,7 +1,7 @@
 from layout import Layout
 
 import big_cube
-import pixel_list
 
 # A dictionary where key is name of layut as a string and the class as a value
 layouts_by_name = {layout.__name__: layout for layout in Layout.__subclasses__()}
+layouts_by_name["Layout"] = Layout

--- a/core/layouts/__init__.py
+++ b/core/layouts/__init__.py
@@ -1,5 +1,6 @@
 from layout import Layout
 
+# Import layouts here to make them detectable to higher level code
 import big_cube
 
 # A dictionary where:

--- a/core/layouts/__init__.py
+++ b/core/layouts/__init__.py
@@ -2,6 +2,8 @@ from layout import Layout
 
 import big_cube
 
-# A dictionary where key is name of layut as a string and the class as a value
+# A dictionary where:
+#     key: name of layout as a string
+#     value: layout class/subclass
 layouts_by_name = {layout.__name__: layout for layout in Layout.__subclasses__()}
 layouts_by_name["Layout"] = Layout

--- a/core/layouts/big_cube.py
+++ b/core/layouts/big_cube.py
@@ -1,7 +1,9 @@
-from strip import Strip
 import numpy as np
 
-class BigCube:
+from strip import Strip
+from layout import Layout
+
+class BigCube(Layout):
     def __init__(self, led_spacing, strip_spacing):
         """
             Big daddy cube

--- a/core/layouts/layout.py
+++ b/core/layouts/layout.py
@@ -1,0 +1,5 @@
+class Layout(object):
+    """
+        At the moment serves nothing more than a placeholder
+    """
+    pass

--- a/core/layouts/layout.py
+++ b/core/layouts/layout.py
@@ -5,4 +5,7 @@ class Layout(object):
         At the moment serves nothing more than a placeholder
     """
     def pixels(self):
+        """
+            This should be overridden so each layout has a generic way to generate a list of pixels
+        """
         return np.array([])

--- a/core/layouts/layout.py
+++ b/core/layouts/layout.py
@@ -1,5 +1,8 @@
+import numpy as np
+
 class Layout(object):
     """
         At the moment serves nothing more than a placeholder
     """
-    pass
+    def pixels(self):
+        return np.array([])

--- a/core/layouts/pixel_list.py
+++ b/core/layouts/pixel_list.py
@@ -1,0 +1,7 @@
+
+class PixelList:
+    """
+        Nothing fancy here, just a list of pixels
+    """
+    def __init__(self, pixels):
+        self.pixels = pixels

--- a/core/layouts/pixel_list.py
+++ b/core/layouts/pixel_list.py
@@ -1,5 +1,6 @@
+from layout import Layout
 
-class PixelList:
+class PixelList(Layout):
     """
         Nothing fancy here, just a list of pixels
     """

--- a/core/layouts/pixel_list.py
+++ b/core/layouts/pixel_list.py
@@ -1,8 +1,0 @@
-from layout import Layout
-
-class PixelList(Layout):
-    """
-        Nothing fancy here, just a list of pixels
-    """
-    def __init__(self, pixels):
-        self.pixels = pixels

--- a/core/layouts/strip.py
+++ b/core/layouts/strip.py
@@ -1,5 +1,5 @@
 from core.devices.pixel import Pixel
-from layput import Layout
+from layout import Layout
 
 import numpy as np
 from numpy.linalg import norm

--- a/core/layouts/strip.py
+++ b/core/layouts/strip.py
@@ -1,9 +1,10 @@
 from core.devices.pixel import Pixel
+from layput import Layout
 
 import numpy as np
 from numpy.linalg import norm
 
-class Strip:
+class Strip(Layout):
     """
         Represents a strip of Leds
         start/direction are two element arrays (x,y)

--- a/core/scene_manager.py
+++ b/core/scene_manager.py
@@ -9,7 +9,7 @@ from utilities.sleep_timer import SleepTimer
 import argparse
 
 from core.devices.fft_device import FftDevice
-from core.devices import construct_output_devices, combine_channel_dicts
+from core.devices import construct_output_devices, construct_input_devices, combine_channel_dicts
 
 class SceneManager(object):
     """
@@ -142,12 +142,9 @@ def run_scene(scene_path):
     parsed_scene = pd.read_json(scene_path)
 
     # Form devices
+    input_devices = construct_input_devices(parsed_scene["InputDevices"])
     output_devices = construct_output_devices(parsed_scene["OutputDevices"])
     
-    input_devices = []
-    if "fft_server" in parsed_scene:
-        input_devices.append(FftDevice(**parsed_scene["fft_server"]))
-
     scene = SceneManager(input_devices, output_devices, **parsed_scene["SceneDetails"])
 
     # Yaaay! Scene time

--- a/core/scene_manager.py
+++ b/core/scene_manager.py
@@ -72,14 +72,14 @@ class SceneManager(object):
         for input_device in self.input_devices:
             # Get data from the queue until cleared
             while True:
-                item = input_device.get_in_queue()
+                item = input_device.get_out_queue()
 
                 if item is None:
                     break
 
                 # Pass onto output devices
                 for output_device in self.output_devices:
-                    output_device.put(item)
+                    output_device.in_queue.put(item)
 
     def process_output_devices(self):
         """
@@ -91,6 +91,7 @@ class SceneManager(object):
             # Get the device queue mutex
             with device.queue_mutex:
                 pixel_dict = device.get_out_queue()
+
                 if pixel_dict:
                     self.output_device_pixel_dictionary_list[i] = pixel_dict
 

--- a/core/scene_manager.py
+++ b/core/scene_manager.py
@@ -39,7 +39,17 @@ class SceneManager(object):
         self.scene_fps = scene_fps
         self.device_fps = device_fps
 
-    def start(self, output_devices, fft_device=None):
+    def init_output_devices(self, devices):
+        # Start Output Processes
+        for device in devices:
+            device.fps = self.device_fps
+            device.start()
+
+    def init_input_devices(self, devices):  
+        for device in device:
+            device.start()
+
+    def start(self, output_devices, input_devices):
         """
             Runs the scene forever. 
             devices is a list of device objects
@@ -50,15 +60,9 @@ class SceneManager(object):
         # Serves as a reference of all the scene pixel colors that get sent to opc in the loop
         output_device_pixel_dictionary_list = [device.pixel_colors_by_channel_255 for device in output_devices]
 
-        # Start Processes
-        for device in output_devices:
-            device.fps = self.device_fps
-            device.start()
-    
-
-        # Start fft_server
-        if fft_device:
-            fft_device.start()
+        # Initialise
+        self.init_output_devices(output_devices)
+        self.init_input_devices(input_devices)
 
         # Main loop
         sleep_timer = SleepTimer(1.0/self.scene_fps)

--- a/core/scene_manager.py
+++ b/core/scene_manager.py
@@ -48,7 +48,29 @@ class SceneManager(object):
         # Serves as a reference of all the scene pixel colors that get sent to opc in the loop
         self.output_device_pixel_dictionary_list = [device.pixel_colors_by_channel_255 for device in self.output_devices]
 
-    def init_output_devices(self):
+    def start(self):
+        """
+            Runs the scene forever. 
+            devices is a list of device objects
+        """
+        # Initialise
+        self.start_input_devices()
+        self.start_output_devices()
+
+        # Main loop
+        sleep_timer = SleepTimer(1.0/self.scene_fps)
+        while True:
+            sleep_timer.start()
+            
+            self.process_input_devices()
+            self.process_output_devices()
+            self.update_opc()
+
+            sleep_timer.sleep()
+
+        # TODO: kill input/output device processes
+
+    def start_output_devices(self):
         """
             Start output device processes
         """
@@ -56,7 +78,7 @@ class SceneManager(object):
             device.fps = self.device_fps
             device.start()
 
-    def init_input_devices(self):  
+    def start_input_devices(self):  
         """
             Start input device processes
         """
@@ -112,28 +134,6 @@ class SceneManager(object):
         # Pass onto OPC client
         for channel, pixels in channels_combined.items():
             self.client.put_pixels(pixels, channel=channel)
-
-    def start(self):
-        """
-            Runs the scene forever. 
-            devices is a list of device objects
-        """
-        # Initialise
-        self.init_input_devices()
-        self.init_output_devices()
-
-        # Main loop
-        sleep_timer = SleepTimer(1.0/self.scene_fps)
-        while True:
-            sleep_timer.start()
-            
-            self.process_input_devices()
-            self.process_output_devices()
-            self.update_opc()
-
-            sleep_timer.sleep()
-
-        # TODO: kill input/output device processes
 
 def run_scene(scene_path):
     """

--- a/descriptors/BigCubeScene.json
+++ b/descriptors/BigCubeScene.json
@@ -5,20 +5,24 @@
         "opc_host": "127.0.0.1",
         "opc_port": 7890
     },
-    "fft_server":
-    {
-        "arduino_ip": "192.168.1.177",
-        "local_ip": "",
-        "start_port": 5003,
-        "data_port": 5009,
-        "start_message": "Start",
-        "buffer_size": 100,
-        "fft_extent_reset_time": 10,
-        "autogainEnable": 0,
-        "no_sound_frequency": 0.2,
-        "ambient_level": 512,
-        "no_mic_level": 100
-    },
+    "InputDevices": [
+        {
+            "type": "FftDevice",
+            "args": {
+                "arduino_ip": "192.168.1.177",
+                "local_ip": "",
+                "start_port": 5003,
+                "data_port": 5009,
+                "start_message": "Start",
+                "buffer_size": 100,
+                "fft_extent_reset_time": 10,
+                "autogainEnable": 0,
+                "no_sound_frequency": 0.2,
+                "ambient_level": 512,
+                "no_mic_level": 100
+            }
+        }
+    ],
     "OutputDevices": [
         {
             "name": "BigDaddy",


### PR DESCRIPTION
This PR contains functionality that allows animations to be swapped out while a device is running an animation. The `Layout` class is leveraged for this for assessing compatibility

- `animations` module `__init__.py` organises animations by layout type (via a new `Layout` class)

- an `animation` class/subclass defines a `layout_type` variable to indicate the type of layout it should be constructed with

- `BigCubeWalk` animation defines a "BigCube" `layout_type` 

- *NEW* `SwoopyTown` animation is defined with the generic, spatially-driven `Layout` layout_type

- `OutputDevice` contains a `layout` variable used for animation compatibility matching

-  `set_animation` command for swapping out animations (tested with code not committed)  